### PR TITLE
Fix intermittent CALayerInvalidGeometry crash after memory warning

### DIFF
--- a/JDFlipNumberView/JDFlipNumberViewImageFactory.m
+++ b/JDFlipNumberView/JDFlipNumberViewImageFactory.m
@@ -64,9 +64,11 @@
 
 - (CGSize)imageSizeForBundleNamed:(NSString *)bundleName;
 {
-    NSArray *images = self.topImages[bundleName];
-    if (images.count > 0) {
-        return [images[0] size];
+    if (bundleName) {
+        NSArray *images = [self topImagesForBundleNamed:bundleName];
+        if (images.count > 0) {
+            return [images[0] size];
+        }
     }
     return CGSizeZero;
 }


### PR DESCRIPTION
Fixes #44 

I could reproduce this crash by mashing cmd-shift-m to trigger memory warnings around the time JDFlipNumberView is laying out. This crash was caused by `_topImages` getting cleared out upon memory warning. Here's the sequence of events:

1. Memory warning -- `_topImages` is cleared
2. `JDFlipNumberView` layoutSubviews is called
3. `JDFlipNumberDigitView`'s `sizeThatFits:` method calls `[self imageSize]` which calls `[factory imageSizeForBundleNamed:self.imageBundleName]`
4. `imageSizeForBundleNamed:` doesn't recreate `_topImages` so the size is returned as `CGSizeZero`
5. `JDFlipNumberDigitView`'s `sizeThatFits:` runs the line `CGFloat origRatioW = imageSize.width/(imageSize.height*2);`, resulting in a `NaN` (divide by 0)
6. The `NaN` is set as the height for the `JDFlipNumberDigitView`'s frame
7. `CALayerInvalidGeometry` crash

This fixes the issue by using `topImagesForBundleNamed:` instead of accessing `topImages` directly. `topImagesForBundleNamed:` recreates the `topImages` if they're not available. 